### PR TITLE
add placeholder compute options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build/
 .ipynb_checkpoints/
 .DS_Store
+__pycache__/

--- a/dev-notes/00_myst_template/curvenote.yml
+++ b/dev-notes/00_myst_template/curvenote.yml
@@ -56,6 +56,14 @@ project:
   subject: Developer Note
   plugins:
     - lorem.mjs
+  # compute configuration, see: https://curvenote.com/docs/publish/live-compute#configuration-via-frontmatter
+  jupyter: true
+  exports:
+    - format: meca
+  # requirements:
+  #   - requirements.txt
+  # resources:
+  #   - data/**/*
 site:
   template: article-theme
   nav: []

--- a/dev-notes/00_myst_template/curvenote.yml
+++ b/dev-notes/00_myst_template/curvenote.yml
@@ -61,7 +61,7 @@ project:
   exports:
     - format: meca
   # requirements:
-  #   - requirements.txt
+  #   - environment.yml
   # resources:
   #   - data/**/*
 site:


### PR DESCRIPTION
This adds an option to enable compute by default `jupyter: true` and then some placeholders for requirements and resource files