### PR TITLE
🔧 adjust `id` pattern

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -9,7 +9,7 @@ jobs:
   create-preview-core-devnotes-draft:
     uses: curvenote/actions/.github/workflows/draft.yml@v1
     with:
-      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,15})$'
+      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,25})$'
       enforce-single-folder: false
       venue: bnext-devnotes
       kind: dev-notes

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -8,7 +8,7 @@ jobs:
   create-core-devnotes-submission:
     uses: curvenote/actions/.github/workflows/submit.yml@v1
     with:
-      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,15})$'
+      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,25})$'
       enforce-single-folder: false
       venue: bnext-devnotes
       kind: dev-notes


### PR DESCRIPTION
The draft and submit workflows had a length limit to the final segment of the id in the template, that was too short and even the template id failed. It has been extended.