### PR TITLE
💾 Add export as download

### DIFF
--- a/dev-notes/03_mthfs/.gitignore
+++ b/dev-notes/03_mthfs/.gitignore
@@ -2,4 +2,4 @@ _build/
 .ipynb_checkpoints/
 .DS_Store
 
-main.pdf
+bnext-mthfs.pdf

--- a/dev-notes/03_mthfs/curvenote.yml
+++ b/dev-notes/03_mthfs/curvenote.yml
@@ -54,7 +54,8 @@ project:
     - format: typst
       template: https://github.com/curvenote-templates/bnext.git
       article: main.md
-      output: main.pdf
+      output: bnext-mthfs.pdf
+      id: article
   requirements:
     - environment.yml
   resources:
@@ -62,6 +63,8 @@ project:
     - experimental/**/*
     - figures/**/*
   downloads:
+    - id: article
+      title: Download PDF
     - file: experiments/20250220-experimental/00-general/MTHFS-labnotebook.pdf
       title: Lab Notebook Entry
 site:


### PR DESCRIPTION
This adds a PDF download link to the article header:

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/88cc2619-012f-4b90-883d-4e8cd07de82b" />

