### PR TITLE
Add DOI for 08_ppk_cell

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -9,7 +9,7 @@ jobs:
   create-preview-core-devnotes-draft:
     uses: curvenote/actions/.github/workflows/draft.yml@v1
     with:
-      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,25})$'
+      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,30})$'
       enforce-single-folder: true
       venue: bnext-devnotes
       kind: devnote

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -8,7 +8,7 @@ jobs:
   create-core-devnotes-submission:
     uses: curvenote/actions/.github/workflows/submit.yml@v1
     with:
-      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,25})$'
+      id-pattern-regex: '^nucleus-devnote-core-(?:[a-zA-Z0-9-_]{3,30})$'
       enforce-single-folder: false
       venue: bnext-devnotes
       kind: devnote

--- a/dev-notes/08_ppk_cell/.gitignore
+++ b/dev-notes/08_ppk_cell/.gitignore
@@ -1,3 +1,4 @@
 _build/
 .ipynb_checkpoints/
 .DS_Store
+bnext-ppk-cell.pdf

--- a/dev-notes/08_ppk_cell/curvenote.yml
+++ b/dev-notes/08_ppk_cell/curvenote.yml
@@ -1,11 +1,11 @@
 version: 1
 project:
+  doi: 10.63765/mwur3749
   # Update this to match `nucleus-devnote-core-<folder>` the folder should be `???`
   id: nucleus-devnote-core-08_ppk-module-in-pure-cell
   # Ensure your title is the same as in your `main.md`
-  title: "Integrating PPK Module in PURE Cells"
-  subtitle: 
-  description: "PPK Module increases protein expression in PURE Cell" 
+  title: 'Integrating PPK Module in PURE Cells'
+  description: 'PPK Module increases protein expression in PURE Cell'
   # Authors should have affiliations, emails and ORCIDs if available
   authors:
     - name: Yen-Yu Hsu

--- a/dev-notes/08_ppk_cell/main.md
+++ b/dev-notes/08_ppk_cell/main.md
@@ -76,8 +76,6 @@ Images were captured using a Revvity Operetta CLS:
 :::::{tab-item} CP
 :sync: tab2-1
 
-::::{grid} 1 1 1 1
-
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Timeseries/CP-both.png
 :label: fig:cp-both-1
 :width: 75%
@@ -91,14 +89,11 @@ Green (488) fluroescence channel.
 :::
 
 Time series of PURE cells containing CP metabolism.
-::::
 :::::
 
 :::::{tab-item} PPK
 :sync: tab2-2
 
-::::{grid} 1 1 1 1
-:label: grid:ppk-both-timelapse
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Timeseries/PPK-both.png
 :label: fig:ppk-both1
 :width: 75%
@@ -112,27 +107,24 @@ Green (488) fluroescence channel.
 :::
 
 Time series of PURE cells containing PPK metabolism.
-::::
 :::::
 
 :::::{tab-item} CP+PPK
 :sync: tab2-2
 
-::::{grid} 1 1 1 1
 
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Timeseries/Combined-both.png
-:label: fig:cp+ppk-both1
+:label: fig:cp-ppk-both1
 :width: 75%
 Combined green (488) and red (561) fluroescence channels. 
 :::
 
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Timeseries/Combined-488.png
-:label: fig:cp+ppk-both2
+:label: fig:cp-ppk-both2
 :width: 75%
 Green (488) fluroescence channel. 
 :::
 Time series of PURE cells containing CP and PPK metabolism.
-::::
 :::::
 Time series of PURE cells containing different metabolic systems, a description of the samples are given in {ref}`tbl:fig1-description`. Every panel represents every 50 minutes. Exposures are matched between wells. Each field of view is 167 um wide. 
 ::::::
@@ -152,7 +144,6 @@ Expression of deGFP in liposomes over time  was calculated from mean intensity o
 
 :::::{tab-item} CP
 :sync: tab4-1
-::::{grid} 1 1 2 2
 
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Endpoint/CP-whole-both.png
 :label: fig:endpoint-cp3
@@ -165,12 +156,10 @@ Combined green (488) and red (561) fluroescence channels.
 :width: 80%
 Green (488) fluroescence channel. 
 :::
-::::
 :::::
 
 :::::{tab-item} PPK
 :sync: tab4-2
-::::{grid} 1 1 2 2
 
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Endpoint/PPK-whole-both.png
 :label: fig:endpoint-ppk1
@@ -183,14 +172,11 @@ Combined green (488) and red (561) fluroescence channels.
 :width: 80%
 Green (488) fluroescence channel. 
 :::
-::::
 :::::
 
 :::::{tab-item} CP+PPK
 :sync: tab4-3
 
-::::{grid} 1 1 2 2
-:label: grid:cpppk
 :::{figure} ./experiments/20250811-PPK-final-cells-Images/Endpoint/Combined-whole-both.png
 :label: fig:endpoint-ppk3
 :width: 80%
@@ -202,7 +188,6 @@ Combined green (488) and red (561) fluroescence channels.
 :width: 80%
 Green (488) fluroescence channel. 
 :::
-::::
 :::::
 Endpoints of each well containing 50 µL of PURE cells encapsulating different metabolic systems, as described in in {ref}`tbl:fig1-description`. The image was taken 6 hours and 40 minutes after each liposome sample was generated. Exposures are matched between wells. Each field of view is ~3.6 mm wide.
 


### PR DESCRIPTION
https://doi.org/10.63765/mwur3749 now resolves to the article.

This PR adds the DOI to the `curvenote.yml` file. It also should fix the build error by allowing slightly longer IDs (this limitation is slightly arbitrary, especially when you are in charge of creating the IDs, so bumping it up is no problem). Finally, the PDF download link wasn't present because the PDF build was not working. The quickest fix was to remove `grid` directives; doing this allowed the PDF to build and did not significantly impact the look of the website.

Let me know what you think.