### PR TITLE
🛶 adds navigation to curvenote.yml

### DIFF
--- a/curvenote.yml
+++ b/curvenote.yml
@@ -33,3 +33,14 @@ site:
     - bnextbio-devnotes_landing.curve.space
   options:
     analytics_plausible: devnotes.nucleus.engineering
+  nav:
+    - title: Home
+      url: /
+    - title: Documentation
+      url: https://docs.nucleus.engineering/
+    - title: Hub
+      url: https://hub.nucleus.engineering/
+    - title: Forum
+      url: https://forum.nucleus.engineering/
+    - title: Contribute
+      url: /contribute


### PR DESCRIPTION
Requried to transtion to the new theme currently previewed at: https://devnotes-next.curve.space/ 
merging this may temporarily double up nav components on the existing site, best if @stevejpurves merges this and disbales the duplicates at the same time
